### PR TITLE
Fix/improve navigation logic

### DIFF
--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -1,19 +1,12 @@
 import { Airport } from "../data/airports";
 
 export type RootStackParamList = {
-  Home: undefined;
-  Flightscreen: {
-    departure: Airport;
-    arrival?: Airport | null;
-  };
+  Homescreen: undefined;
+  Flightscreen: undefined;
 };
 
 export type FlightscreenTabParamList = {
-  Departure: { departure: Airport };
-  Arrival: { arrival?: Airport | null };
-  Overall: { departure: Airport; arrival?: Airport | null };
-  AirportTab: {
-    departure?: Airport | null;
-    arrival?: Airport | null;
-  };
+  DepartureTab: { departure?: Airport };
+  ArrivalTab: { arrival?: Airport };
+  Overall: { departure?: Airport; arrival?: Airport };
 };

--- a/screens/Flightscreen.tsx
+++ b/screens/Flightscreen.tsx
@@ -1,28 +1,16 @@
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { CommonActions } from "@react-navigation/native";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { CommonActions, useNavigation } from "@react-navigation/native";
 import React from "react";
 import { View } from "react-native";
 import { Appbar, BottomNavigation, useTheme } from "react-native-paper";
-import { Airport } from "../data/airports";
-import {
-  FlightscreenTabParamList,
-  RootStackParamList,
-} from "../navigation/types";
+import { FlightscreenTabParamList } from "../navigation/types";
 import AirportTab from "./tabs/AirportTab";
 import OverallTab from "./tabs/OverallTab";
 
-type Props = NativeStackScreenProps<RootStackParamList, "Flightscreen">;
-
-type BottomBarProps = {
-  departure: Airport;
-  arrival?: Airport | null;
-};
-
-export default function Flightscreen({ route, navigation }: Props) {
-  const { departure, arrival } = route.params;
+export default function Flightscreen() {
   const { colors } = useTheme();
+  const navigation = useNavigation();
 
   const _goBack = () => navigation.goBack();
   const _handleRefresh = () => console.log("Refreshing");
@@ -41,7 +29,7 @@ export default function Flightscreen({ route, navigation }: Props) {
         />
       </Appbar.Header>
       <View style={{ flex: 1 }}>
-        <BottomBar departure={departure} arrival={arrival} />
+        <BottomBar />
       </View>
     </View>
   );
@@ -49,7 +37,7 @@ export default function Flightscreen({ route, navigation }: Props) {
 
 const Tab = createBottomTabNavigator<FlightscreenTabParamList>();
 
-const BottomBar = ({ departure, arrival }: BottomBarProps) => {
+const BottomBar = () => {
   const { colors } = useTheme();
 
   return (
@@ -103,9 +91,8 @@ const BottomBar = ({ departure, arrival }: BottomBarProps) => {
       )}
     >
       <Tab.Screen
-        name="Departure"
+        name="DepartureTab"
         component={AirportTab}
-        initialParams={{ departure }}
         options={{
           tabBarIcon: ({ color }) => (
             <MaterialCommunityIcons
@@ -117,9 +104,8 @@ const BottomBar = ({ departure, arrival }: BottomBarProps) => {
         }}
       />
       <Tab.Screen
-        name="Arrival"
+        name="ArrivalTab"
         component={AirportTab}
-        initialParams={{ arrival }}
         options={{
           tabBarIcon: ({ color }) => (
             <MaterialCommunityIcons
@@ -133,7 +119,6 @@ const BottomBar = ({ departure, arrival }: BottomBarProps) => {
       <Tab.Screen
         name="Overall"
         component={OverallTab}
-        initialParams={{ departure, arrival }}
         options={{
           tabBarIcon: ({ color }) => (
             <MaterialCommunityIcons

--- a/screens/Homescreen.tsx
+++ b/screens/Homescreen.tsx
@@ -21,6 +21,7 @@ import { Airport, airports } from "../data/airports";
 import { getFavorites, updateFavorites } from "../data/store";
 import { RootStackParamList } from "../navigation/types";
 import { haversineDistance } from "../utils/geoUtils";
+import { useFlightStore } from "../utils/flightStore";
 
 const airportsData = airports;
 
@@ -29,8 +30,10 @@ export default function Homescreen() {
   const [favorites, setFavorites] = useState<string[]>([]);
   const [departure, setDeparture] = useState<string | null>(null);
   const [arrival, setArrival] = useState<string | null>(null);
-  const [depAirport, setDepAirport] = useState<Airport | null>(null);
-  const [arrAirport, setArrAirport] = useState<Airport | null>(null);
+  const setDepAirport = useFlightStore((s) => s.setDepAirport);
+  const setArrAirport = useFlightStore((s) => s.setArrAirport);
+  const depAirport = useFlightStore((s) => s.depAirport);
+  const arrAirport = useFlightStore((s) => s.arrAirport);
   const [selectedAirport, setSelectedAirport] = useState<Airport | null>(null);
   const [activeField, setActiveField] = useState<
     "departure" | "arrival" | null
@@ -45,7 +48,7 @@ export default function Homescreen() {
   const { colors } = useTheme();
 
   const navigation =
-    useNavigation<NativeStackNavigationProp<RootStackParamList, "Home">>();
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const filteredAirports = airports.filter((a) => {
     if (!search) {
@@ -79,10 +82,7 @@ export default function Homescreen() {
   const handleGoToBrief = () => {
     if (!depAirport) return;
     setShowModal(false);
-    navigation.navigate("Flightscreen", {
-      departure: depAirport,
-      arrival: arrAirport ?? null,
-    });
+    navigation.navigate("Flightscreen");
   };
 
   const handleNewTrip = () => {

--- a/screens/tabs/AirportTab.tsx
+++ b/screens/tabs/AirportTab.tsx
@@ -15,20 +15,33 @@ import Turbulence from "../../features/turbulence/Turbulence";
 import LocationForecast from "../../features/weather/LocationForecast";
 import { FlightscreenTabParamList } from "../../navigation/types";
 import { getFavorites, updateFavorites } from "../../data/store";
+import { useFlightStore } from "../../utils/flightStore";
 
 type AirportTabProps = BottomTabScreenProps<
   FlightscreenTabParamList,
-  "AirportTab"
+  "DepartureTab" | "ArrivalTab"
 >;
 
 export default function AirportTab({ route }: AirportTabProps) {
-  const { departure, arrival } = route.params;
-  const [airport, setAirport] = useState<Airport | null>(
-    departure ?? arrival ?? null
-  );
+  const isDeparture = route.name === "DepartureTab";
+  const isArrival = route.name === "ArrivalTab";
 
-  if (!airport) return <NoArrivalComponent setArrAirport={setAirport} />;
-  return <AirportInfo airport={airport} />;
+  const departure = useFlightStore((s) => s.depAirport);
+  const arrival = useFlightStore((s) => s.arrAirport);
+  const setArrival = useFlightStore((s) => s.setArrAirport);
+
+  if (isDeparture) {
+    return <AirportInfo airport={departure!} />;
+  }
+
+  if (isArrival) {
+    if (!arrival) {
+      return <NoAirportComponent onSelectAirport={setArrival} />;
+    }
+    return <AirportInfo airport={arrival} />;
+  }
+  // (should never happen)
+  return null;
 }
 
 type AirportInfoProps = {
@@ -89,11 +102,11 @@ const AirportInfo = ({ airport }: AirportInfoProps) => {
   );
 };
 
-type ArrivalProps = {
-  setArrAirport: (arrival: Airport) => void;
+type NoAirportComponentProps = {
+  onSelectAirport: (airport: Airport) => void;
 };
 
-const NoArrivalComponent = ({ setArrAirport }: ArrivalProps) => {
+const NoAirportComponent = ({ onSelectAirport }: NoAirportComponentProps) => {
   const [search, setSearch] = useState("");
   const [favorites, setFavorites] = useState<string[]>([]);
   const [activeField, setActiveField] = useState(false);
@@ -146,7 +159,7 @@ const NoArrivalComponent = ({ setArrAirport }: ArrivalProps) => {
         style={{ marginTop: 10 }}
         left={
           <TextInput.Icon
-            icon="airplane-landing"
+            icon={"airplane-landing"}
             size={20}
             color={colors.tertiary}
           />
@@ -188,7 +201,7 @@ const NoArrivalComponent = ({ setArrAirport }: ArrivalProps) => {
               )}
               onPress={() => {
                 Keyboard.dismiss();
-                setArrAirport(item);
+                onSelectAirport(item);
                 setActiveField(false);
               }}
             />

--- a/screens/tabs/OverallTab.tsx
+++ b/screens/tabs/OverallTab.tsx
@@ -1,18 +1,13 @@
-import { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
 import React, { useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Button, Icon, Menu, Text, useTheme } from "react-native-paper";
 import Sigchart from "../../features/sigchart/Sigchart";
-import { FlightscreenTabParamList } from "../../navigation/types";
+import { useFlightStore } from "../../utils/flightStore";
 import { haversineDistance } from "../../utils/geoUtils";
 
-type OverallTabProps = BottomTabScreenProps<
-  FlightscreenTabParamList,
-  "Overall"
->;
-
-export default function OverallTab({ route }: OverallTabProps) {
-  const { departure, arrival } = route.params;
+export default function OverallTab() {
+  const departure = useFlightStore((s) => s.depAirport);
+  const arrival = useFlightStore((s) => s.arrAirport);
   const { colors } = useTheme();
   return (
     <ScrollView

--- a/utils/flightStore.ts
+++ b/utils/flightStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { Airport } from "../data/airports";
+
+
+type FlightState = {
+  depAirport: Airport | null;
+  arrAirport: Airport | null;
+  setDepAirport: (airport: Airport | null) => void;
+  setArrAirport: (airport: Airport | null) => void;
+};
+
+export const useFlightStore = create<FlightState>((set) => ({
+  depAirport: null,
+  arrAirport: null,
+  setDepAirport: (airport) => set({ depAirport: airport }),
+  setArrAirport: (airport) => set({ arrAirport: airport }),
+}));


### PR DESCRIPTION
I decided to use `zustand` for global state management regarding departure and arrival airport. 
It makes my logic of letting arrival airport be `null` when navigating to flightscreen much easier and in later versions it enables me to let users change airports without having to go back to homescreen.